### PR TITLE
feat: info cards boilerplate info from vantage API

### DIFF
--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -8,6 +8,7 @@ const { fetchStockData } = useStockDataStore()
 const route = useRoute()
 const inputText = ref<any>('')
 const param = ref<any>(route.params.symbol)
+const timeSeries = ref<any>('TIME_SERIES_DAILY_ADJUSTED')
 </script>
 
 <template>
@@ -18,7 +19,7 @@ const param = ref<any>(route.params.symbol)
         type="text"
         placeholder="Symbol"
         class="z-10 w-full rounded-md border-[0.5px] border-neutral-300 p-2 pr-10 focus:placeholder-transparent"
-        @keydown.enter.prevent="fetchStockData(inputText)"
+        @keydown.enter.prevent="fetchStockData(inputText, timeSeries)"
       />
       <span
         class="material-symbols-outlined pointer-events-none absolute inset-y-0 right-5 z-20 flex w-3 cursor-pointer items-center pr-3 opacity-50"

--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -1,10 +1,60 @@
 <script lang="ts" setup>
-import SearchBar from "@/components/SearchBar.vue"
-import CardContainer from "@/components/UI/CardContainer.vue"
+import SearchBar from '@/components/SearchBar.vue'
+import CardContainer from '@/components/UI/CardContainer.vue'
 
-import useStocksDataStore from "@/stores/stocksData.store.ts"
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
 
-const { symbol } = useStocksDataStore()
+import useStocksDataStore from '@/stores/stocksData.store.ts'
+
+const stocksDataStore = useStocksDataStore()
+const { apiKey, dailyData }: any = storeToRefs(stocksDataStore)
+
+const metaData: any = computed(() => {
+  const values = Object.values(dailyData.value)
+  return values[0]
+})
+
+const dailyTimeSeriesData: any = computed(() => {
+  const values = Object.values(dailyData.value);
+  return values[1]
+})
+
+const symbol = computed(() => {
+  if (metaData.value) {
+    const keys = Object.keys(metaData.value);
+    return metaData.value[keys[1]]
+  }
+  return ''
+})
+
+const price = computed(() => {
+  if (dailyTimeSeriesData.value) {
+    const closingData: any = Object.values(dailyTimeSeriesData.value)[0]
+    const closingDataKeys = Object.keys(closingData)
+    return closingData[closingDataKeys[3]]
+  }
+  return ''
+})
+
+const previousClosingPrice = computed(() => {
+  if (dailyTimeSeriesData.value) {
+    const closingData: any = Object.values(dailyTimeSeriesData.value)[1]
+    const closingDataKeys = Object.keys(closingData)
+    return closingData[closingDataKeys[3]]
+  }
+  return ''
+})
+
+const priceChange = computed(() => (price.value - previousClosingPrice.value).toFixed(2))
+
+const date = computed(() => {
+  if (metaData.value) {
+    const keys = Object.keys(metaData.value);
+    return metaData.value[keys[2]]
+  }
+  return ''
+})
 </script>
 
 <template>
@@ -12,7 +62,24 @@ const { symbol } = useStocksDataStore()
   <div class="p-6">
     <h2 class="mb-4 text-xl font-semibold">Price Action</h2>
     <CardContainer>
-      {{ symbol }}
+      <header>
+        <h1 class="text-2xl font-semibold">
+          {{ symbol }}
+        </h1>
+      </header>
+      <h2>Stock and Price Overview</h2>
+      <div class="flex items-center gap-2">
+        <h2 class="text-3xl font-bold">
+          {{ price }}
+        </h2>
+        <div class="flex h-fit items-center gap-2 rounded-md bg-[#2FE900] px-3 py-0.5 text-center">
+          <span class="text-sm text-center">
+            {{ priceChange }}
+          </span>
+          <span class="material-symbols-outlined">trending_up</span>
+        </div>
+      </div>
+      {{ date }}
     </CardContainer>
   </div>
 </template>

--- a/src/stores/stocksData.store.ts
+++ b/src/stores/stocksData.store.ts
@@ -3,31 +3,27 @@ import axios from 'axios'
 
 interface State {
   apiKey: string
-  data: any
+  dailyData: any,
 }
 
 export const useProblemsStore = defineStore('stocks', {
   state: (): State => {
     return {
       apiKey: 'LTSY55G9R1CJFQ11',
-      data: null
+      dailyData: {}
     }
   },
   actions: {
-    fetchStockData(ticker: string) {
+    fetchStockData(ticker: string, timeSeries: string) {
       axios
         .get(
-          `https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=${ticker.toUpperCase()}&interval=5min&apikey=demo${
+          `https://www.alphavantage.co/query?function=${timeSeries}&symbol=${ticker.toUpperCase()}&interval=5min&apikey=${
             this.apiKey
           }`
         )
         .then((response) => {
           console.log(response.data)
-          this.data = response.data
-
-          const firstDataKey = Object.keys(this.data)[0]
-          const metaDataKeys = Object.keys(this.data[firstDataKey])
-          this.symbol = this.data[firstDataKey][metaDataKeys[1]]
+          this.dailyData = response.data
         })
         .catch((error) => {
           console.error(error)

--- a/src/stores/stocksData.store.ts
+++ b/src/stores/stocksData.store.ts
@@ -2,7 +2,6 @@ import { defineStore } from 'pinia'
 import axios from 'axios'
 
 interface State {
-  symbol: string
   apiKey: string
   data: any
 }
@@ -10,7 +9,6 @@ interface State {
 export const useProblemsStore = defineStore('stocks', {
   state: (): State => {
     return {
-      symbol: '',
       apiKey: 'LTSY55G9R1CJFQ11',
       data: null
     }


### PR DESCRIPTION
# feat: info cards boilerplate info from vantage API

**What is in this PR:**
- fetch data from vantage api with axis and store payload into global state
- use data in dashboard component to create info cards

**Here is what it looks like:**
<img width="1440" alt="Screen Shot 2023-05-14 at 10 28 59 PM" src="https://github.com/salamhis2019/stocks-2.0/assets/90210361/fa1aa71c-598a-45b8-8ffd-a313e3759ca4">

