### PR TITLE
feat: Price change badge component creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.4.0",
+        "clsx": "^1.2.1",
         "pinia": "^2.0.35",
         "vue": "^3.2.47",
         "vue-router": "^4.1.6"
@@ -2339,6 +2340,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -8346,6 +8355,11 @@
           }
         }
       }
+    },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
+    "clsx": "^1.2.1",
     "pinia": "^2.0.35",
     "vue": "^3.2.47",
     "vue-router": "^4.1.6"

--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -73,7 +73,7 @@ const date = computed(() => {
         <h2 class="text-3xl font-bold">
           {{ price }}
         </h2>
-        <PriceBadge :trending="trending" :symbol="priceChangeSymbol" :price="priceChange" />
+        <PriceBadge :price="priceChange" />
       </div>
       {{ date }}
     </CardContainer>

--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import SearchBar from '@/components/SearchBar.vue'
 import CardContainer from '@/components/UI/CardContainer.vue'
+import PriceBadge from '@/components/UI/PriceBadge.vue'
 
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
@@ -8,7 +9,7 @@ import { storeToRefs } from 'pinia'
 import useStocksDataStore from '@/stores/stocksData.store.ts'
 
 const stocksDataStore = useStocksDataStore()
-const { apiKey, dailyData }: any = storeToRefs(stocksDataStore)
+const { dailyData }: any = storeToRefs(stocksDataStore)
 
 const metaData: any = computed(() => {
   const values = Object.values(dailyData.value)
@@ -46,7 +47,7 @@ const previousClosingPrice = computed(() => {
   return ''
 })
 
-const priceChange = computed(() => (price.value - previousClosingPrice.value).toFixed(2))
+const priceChange = computed(() => Number(price.value - previousClosingPrice.value).toFixed(2))
 
 const date = computed(() => {
   if (metaData.value) {
@@ -72,12 +73,7 @@ const date = computed(() => {
         <h2 class="text-3xl font-bold">
           {{ price }}
         </h2>
-        <div class="flex h-fit items-center gap-2 rounded-md bg-[#2FE900] px-3 py-0.5 text-center">
-          <span class="text-sm text-center">
-            {{ priceChange }}
-          </span>
-          <span class="material-symbols-outlined">trending_up</span>
-        </div>
+        <PriceBadge :trending="trending" :symbol="priceChangeSymbol" :price="priceChange" />
       </div>
       {{ date }}
     </CardContainer>

--- a/src/components/UI/PriceBadge.vue
+++ b/src/components/UI/PriceBadge.vue
@@ -1,0 +1,55 @@
+<script lang="ts" setup>
+import { computed, defineProps } from 'vue'
+import { clsx } from 'clsx'
+
+const props = defineProps({
+  trending: {
+    type: String,
+    validator: (s: any) => ['up', 'down', 'neutral'].includes(s),
+    default: 'neutral'
+  },
+  symbol: {
+    type: String,
+    validator: (s: any) => ['trending_up', 'trending_down', 'minimize'].includes(s),
+    default: 'easy'
+  },
+  price: {
+    default: ''
+  }
+})
+
+const baseClasses = 'flex h-fit items-center gap-2 rounded-md px-3 py-0.5 text-center'
+
+const colorClasses: any = {
+  up: 'bg-[#2FE900]',
+  down: 'bg-[#FF0000]',
+  neutral: 'bg-[#E3E3E3]'
+}
+
+const trending = computed(() => {
+  if (Number(props.price) > 0) {
+    return 'up'
+  } else if (Number(props.price) === 0) {
+    return 'neutral'
+  } else {
+    return 'down'
+  }
+})
+
+const priceChangeSymbol = computed(() => {
+  if (Number(props.price) > 0) {
+    return 'trending_up'
+  } else if (Number(props.price) === 0) {
+    return 'horizontal_rule'
+  } else {
+    return 'trending_down'
+  }
+})
+</script>
+
+<template>
+  <div :class="clsx(baseClasses, colorClasses[trending])">
+    <span>{{ price }}</span>
+    <span class="material-symbols-outlined">{{ priceChangeSymbol }}</span>
+  </div>
+</template>

--- a/src/components/UI/PriceBadge.vue
+++ b/src/components/UI/PriceBadge.vue
@@ -18,7 +18,7 @@ const props = defineProps({
   }
 })
 
-const baseClasses = 'flex h-fit items-center gap-2 rounded-md px-3 py-0.5 text-center'
+const baseClasses = 'flex h-fit items-center gap-2 rounded-md px-3 py-0.5 text-center text-sm'
 
 const colorClasses: any = {
   up: 'bg-[#2FE900]',
@@ -50,6 +50,6 @@ const priceChangeSymbol = computed(() => {
 <template>
   <div :class="clsx(baseClasses, colorClasses[trending])">
     <span>{{ price }}</span>
-    <span class="material-symbols-outlined">{{ priceChangeSymbol }}</span>
+    <span class="material-symbols-outlined text-sm font-semibold">{{ priceChangeSymbol }}</span>
   </div>
 </template>


### PR DESCRIPTION
# feat: Price change badge component creation

**What is in this PR:**
- create price change badge component
- import and install `clsx` to use in classes and props
- pass price as prop and handle trend and class color locally in price badge component

**Here is what it looks like:**
<img width="222" alt="Screen Shot 2023-05-14 at 11 11 13 PM" src="https://github.com/salamhis2019/stocks-2.0/assets/90210361/b219fd83-fd6e-4423-ae5d-f56c4dcd6e74">
<img width="182" alt="Screen Shot 2023-05-14 at 11 11 26 PM" src="https://github.com/salamhis2019/stocks-2.0/assets/90210361/c9ca74a6-36a8-461a-803b-7abadb23a5e3">
<img width="131" alt="Screen Shot 2023-05-14 at 11 11 36 PM" src="https://github.com/salamhis2019/stocks-2.0/assets/90210361/f77333df-cf8c-4945-b77e-57cbe51c6aba">

