### PR TITLE
feat: add percentage value to info cards

### DIFF
--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -50,6 +50,20 @@ const date = computed(() => {
   }
   return ''
 })
+
+const percentChange = computed(() =>
+  ((Number(priceChange.value) / Number(previousClosingPrice.value)) * 100).toFixed(2)
+)
+
+const classes = computed(() => {
+  if (Number(percentChange.value) > 0) {
+    return 'text-green-600'
+  } else if (Number(percentChange.value) === 0) {
+    return 'text-neutral-600'
+  } else {
+    return 'text-red-600'
+  }
+})
 </script>
 
 <template>
@@ -67,6 +81,7 @@ const date = computed(() => {
           {{ currentPrice }}
         </h2>
         <PriceBadge :price="priceChange" />
+        <p class="text-sm font-medium" :class="classes">({{ percentChange }}%)</p>
       </div>
       <p class="text-sm text-neutral-500">{{ date }}</p>
     </CardContainer>


### PR DESCRIPTION
# feat: add percentage value to info cards

**What is in this PR:**
- add calculation for daily percentage change based on stock previous closing price and current closing price

**Here is what it looks like:**
<img width="360" alt="Screen Shot 2023-05-15 at 10 38 12 PM" src="https://github.com/salamhis2019/stocks-2.0/assets/90210361/707e273d-40d2-42f7-8f64-aac4eabb8034">

