### PR TITLE
feat: add previous close and current opening price cards

### DIFF
--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -30,17 +30,20 @@ const currentPrice = computed(() => {
   return ''
 })
 
-const previousClosingPrice = computed(() => {
+const previousClosingPrice: any = computed(() => {
   if (dailyTimeSeriesData.value) {
     const closingData: any = Object.values(dailyTimeSeriesData.value)[1]
     const closingDataKeys = Object.keys(closingData)
-    return closingData[closingDataKeys[3]]
+    return {
+      price: closingData[closingDataKeys[3]],
+      date: Object.keys(dailyTimeSeriesData.value)[1]
+    }
   }
   return ''
 })
 
 const priceChange = computed(() =>
-  Number(currentPrice.value - previousClosingPrice.value).toFixed(2)
+  Number(currentPrice.value - previousClosingPrice.value.price).toFixed(2)
 )
 
 const date = computed(() => {
@@ -52,7 +55,7 @@ const date = computed(() => {
 })
 
 const percentChange = computed(() =>
-  ((Number(priceChange.value) / Number(previousClosingPrice.value)) * 100).toFixed(2)
+  ((Number(priceChange.value) / Number(previousClosingPrice.value.price)) * 100).toFixed(2)
 )
 
 const classes = computed(() => {
@@ -87,9 +90,21 @@ const classes = computed(() => {
         <p class="text-sm text-neutral-500">{{ date }}</p>
       </CardContainer>
       <CardContainer>
-        <header>
-          <h2>Today</h2>
-        </header>
+        <div class="flex h-full flex-col justify-between">
+          <header>
+            <h2>Today</h2>
+          </header>
+          <div class="flex w-full justify-between">
+            <div>
+              <p>Open</p>
+              <p class="text-3xl font-bold">{{ previousClosingPrice }}</p>
+              <p>{{ date }}</p>
+            </div>
+            <div>
+              <p>Previous Close</p>
+            </div>
+          </div>
+        </div>
       </CardContainer>
     </div>
   </div>

--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -21,11 +21,11 @@ const dailyTimeSeriesData: any = computed(() => {
   return values[1]
 })
 
-const currentPrice = computed(() => {
+const currentPrice: any = computed(() => {
   if (dailyTimeSeriesData.value) {
     const closingData: any = Object.values(dailyTimeSeriesData.value)[0]
     const closingDataKeys = Object.keys(closingData)
-    return closingData[closingDataKeys[3]]
+    return { close: closingData[closingDataKeys[3]], open: closingData[closingDataKeys[0]] }
   }
   return ''
 })
@@ -43,7 +43,7 @@ const previousClosingPrice: any = computed(() => {
 })
 
 const priceChange = computed(() =>
-  Number(currentPrice.value - previousClosingPrice.value.price).toFixed(2)
+  Number(currentPrice.value.close - previousClosingPrice.value.price).toFixed(2)
 )
 
 const date = computed(() => {
@@ -82,7 +82,7 @@ const classes = computed(() => {
         <h2 class="text-neutral-600">Stock and Price Overview</h2>
         <div class="flex items-center gap-2">
           <h2 class="my-1 text-3xl font-bold">
-            {{ currentPrice }}
+            {{ currentPrice.close }}
           </h2>
           <PriceBadge :price="priceChange" />
           <p class="text-sm font-medium" :class="classes">({{ percentChange }}%)</p>
@@ -92,16 +92,18 @@ const classes = computed(() => {
       <CardContainer>
         <div class="flex h-full flex-col justify-between">
           <header>
-            <h2>Today</h2>
+            <h2 class="text-xl font-semibold">Today</h2>
           </header>
           <div class="flex w-full justify-between">
-            <div>
-              <p>Open</p>
-              <p class="text-3xl font-bold">{{ previousClosingPrice }}</p>
-              <p>{{ date }}</p>
+            <div class="flex flex-col gap-2">
+              <p class="text-neutral-600">Open</p>
+              <p class="text-3xl font-bold">{{ currentPrice.open }}</p>
+              <p class="text-sm text-neutral-500">{{ date }}</p>
             </div>
-            <div>
-              <p>Previous Close</p>
+            <div class="flex flex-col gap-2">
+              <p class="text-neutral-600">Previous Close</p>
+              <p class="text-3xl font-bold">{{ previousClosingPrice.price }}</p>
+              <p class="text-sm text-neutral-500">{{ previousClosingPrice.date }}</p>
             </div>
           </div>
         </div>

--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -70,20 +70,27 @@ const classes = computed(() => {
   <SearchBar />
   <div class="p-6">
     <h2 class="mb-4 text-xl font-semibold">Price Action</h2>
-    <CardContainer>
-      <header class="mb-2 flex items-center gap-3">
-        <img :src="companyData.logo" class="h-12" alt="" />
-        <h1 class="text-2xl font-semibold">{{ companyData.ticker }} - {{ companyData.name }}</h1>
-      </header>
-      <h2 class="text-neutral-600">Stock and Price Overview</h2>
-      <div class="flex items-center gap-2">
-        <h2 class="my-1 text-3xl font-bold">
-          {{ currentPrice }}
-        </h2>
-        <PriceBadge :price="priceChange" />
-        <p class="text-sm font-medium" :class="classes">({{ percentChange }}%)</p>
-      </div>
-      <p class="text-sm text-neutral-500">{{ date }}</p>
-    </CardContainer>
+    <div class="flex gap-6">
+      <CardContainer>
+        <header class="mb-2 flex items-center gap-3">
+          <img :src="companyData.logo" class="h-12" alt="" />
+          <h1 class="text-2xl font-semibold">{{ companyData.ticker }} - {{ companyData.name }}</h1>
+        </header>
+        <h2 class="text-neutral-600">Stock and Price Overview</h2>
+        <div class="flex items-center gap-2">
+          <h2 class="my-1 text-3xl font-bold">
+            {{ currentPrice }}
+          </h2>
+          <PriceBadge :price="priceChange" />
+          <p class="text-sm font-medium" :class="classes">({{ percentChange }}%)</p>
+        </div>
+        <p class="text-sm text-neutral-500">{{ date }}</p>
+      </CardContainer>
+      <CardContainer>
+        <header>
+          <h2>Today</h2>
+        </header>
+      </CardContainer>
+    </div>
   </div>
 </template>

--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -58,7 +58,7 @@ const percentChange = computed(() =>
 const classes = computed(() => {
   if (Number(percentChange.value) > 0) {
     return 'text-green-600'
-  } else if (Number(percentChange.value) === 0) {
+  } else if (Number(percentChange.value) === 0 || Number.isNaN(Number(percentChange.value))) {
     return 'text-neutral-600'
   } else {
     return 'text-red-600'

--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -25,7 +25,10 @@ const currentPrice: any = computed(() => {
   if (dailyTimeSeriesData.value) {
     const closingData: any = Object.values(dailyTimeSeriesData.value)[0]
     const closingDataKeys = Object.keys(closingData)
-    return { close: closingData[closingDataKeys[3]], open: closingData[closingDataKeys[0]] }
+    return {
+      close: closingData[closingDataKeys[3]],
+      open: closingData[closingDataKeys[0]]
+    }
   }
   return ''
 })

--- a/src/components/UI/CardContainer.vue
+++ b/src/components/UI/CardContainer.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex h-fit w-96 flex-col justify-center rounded-xl border-[0.5px] border-neutral-300 bg-white p-6 shadow-md"
+    class="flex h-48 w-96 flex-col justify-center rounded-xl border-[0.5px] border-neutral-300 bg-white p-6 shadow-md"
   >
     <slot></slot>
   </div>


### PR DESCRIPTION
# feat: add previous close and current opening price cards

**What is in this PR:**
- add info card that contains previous and current opening price

**Here is what it looks like:**
<img width="375" alt="Screen Shot 2023-05-16 at 5 25 14 PM" src="https://github.com/salamhis2019/stocks-2.0/assets/90210361/a173a7e2-75c7-4269-bf04-6ccad9f2cb7c">
