### PR TITLE
refactor: pass height and width props to card container and change font sizing for overview section

### DIFF
--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -81,7 +81,7 @@ const description = computed(() => {
   <div class="p-6">
     <h2 class="mb-4 text-xl font-semibold">Price Action</h2>
     <div class="flex gap-6">
-      <CardContainer>
+      <CardContainer :width="'w-96'" :height="'h-48'">
         <header class="mb-2 flex items-center gap-3">
           <img :src="companyData.logo" class="h-12" alt="" />
           <h1 class="text-2xl font-semibold">{{ companyData.ticker }} - {{ companyData.name }}</h1>
@@ -96,7 +96,7 @@ const description = computed(() => {
         </div>
         <p class="text-sm text-neutral-500">{{ date }}</p>
       </CardContainer>
-      <CardContainer>
+      <CardContainer :width="'w-96'" :height="'h-48'">
         <div class="flex h-full flex-col justify-between">
           <header>
             <h2 class="text-xl font-semibold">Today</h2>
@@ -116,8 +116,9 @@ const description = computed(() => {
         </div>
       </CardContainer>
     </div>
-    <hr class="mt-6 border-neutral-300" />
-    <h2 class="mb-4 mt-6 text-2xl font-semibold">Overview</h2>
-    <p>{{ description }}</p>
+    <CardContainer :width="'w-full'">
+      <h2 class="text-2xl font-semibold">Overview</h2>
+      <p>{{ description }}</p>
+    </CardContainer>
   </div>
 </template>

--- a/src/components/StockDashboard.vue
+++ b/src/components/StockDashboard.vue
@@ -117,8 +117,8 @@ const description = computed(() => {
       </CardContainer>
     </div>
     <CardContainer :width="'w-full'">
-      <h2 class="text-2xl font-semibold">Overview</h2>
-      <p>{{ description }}</p>
+      <h2 class="mb-2 text-xl font-semibold">Overview</h2>
+      <p class="text-sm text-neutral-800">{{ description }}</p>
     </CardContainer>
   </div>
 </template>

--- a/src/components/UI/CardContainer.vue
+++ b/src/components/UI/CardContainer.vue
@@ -1,5 +1,22 @@
+<script lang="ts" setup>
+import { computed, defineProps } from 'vue'
+
+const props: any = defineProps({
+  width: {
+    type: String
+  },
+  height: {
+    type: String
+  }
+})
+
+const classes = computed(() => {
+  return `${props.width} ${props.height}`
+})
+</script>
+
 <template>
-  <div class="shadow-large flex h-48 w-96 flex-col justify-center rounded-xl bg-white p-6">
+  <div class="shadow-large flex flex-col justify-center rounded-xl bg-white p-6" :class="classes">
     <slot></slot>
   </div>
 </template>


### PR DESCRIPTION
# refactor: pass height and width props to card container and change font sizing for overview section

**What is in this PR:**
- allow card container to accept props to configure height and width
- wrap overview section in card container
- add different font sizes for all overview section items

**Here is what it looks like:**
<img width="1440" alt="Screen Shot 2023-05-29 at 10 41 55 PM" src="https://github.com/salamhis2019/stocks-2.0/assets/90210361/2a08c45f-5f24-4418-9f6a-b496b3de8d64">